### PR TITLE
RBAC, Kubernetes Version and fixes

### DIFF
--- a/scripts/aks-vnet-all-parameters.json
+++ b/scripts/aks-vnet-all-parameters.json
@@ -24,7 +24,7 @@
             "value": null
         },
         "kubernetesVersion": {
-            "value": "1.9.6"
+            "value": "1.11.2"
         },
         "workspaceName": {
             "value": "DefaultWorkspace-<subid>-WEU"
@@ -52,6 +52,9 @@
         },
         "dockerBridgeCidr": {
             "value": "172.17.0.1/16"
+        },
+        "enableRbac":{
+            "value": true
         }
     }
 }

--- a/scripts/aks-vnet-all.json
+++ b/scripts/aks-vnet-all.json
@@ -159,6 +159,13 @@
             "metadata": {
                 "description": "A CIDR notation IP for Docker bridge."
             }
+        },
+        "enableRbac": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "boolean flag to turn on and off of rbac"
+            }
         }
     },
     "resources": [
@@ -170,7 +177,7 @@
             "name": "[parameters('resourceName')]",
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
-                "enableRBAC": false,
+                "enableRBAC": "[parameters('enableRbac')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
                 "addonProfiles": {
                     "httpApplicationRouting": {

--- a/scripts/deploy-aks-cutom-vnet.sh
+++ b/scripts/deploy-aks-cutom-vnet.sh
@@ -46,9 +46,10 @@ az group deployment create -g ${AKS_RG} \
     servicePrincipalClientSecret=${SPN_PW} \
     workspaceRegion=${OMS_LOCATION} \
     workspaceName=${OMS_WORKSPACE_NAME} \
-    omsWorkspaceId=${OMS_WORKSPACE_ID}
+    omsWorkspaceId=${OMS_WORKSPACE_ID} \
     serviceCidr=${AKS_SVC_CIDR} \
     dnsServiceIP=${AKS_DNS_IP} \
+    enableRbac=true
 
 # We need to update the VNET with the Route Table and NSG from AKS
 # First, find the resources we need : AKS RG, Route table, NSG and subnet id.     

--- a/scripts/deploy-jumpbox.sh
+++ b/scripts/deploy-jumpbox.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -x
+
+. ./env.sh
+
 # create nsg for nic
 export VM_NIC_NSG=aks-jumpbox-nsg
 export VM_NIC=aks-jumpbox-nic


### PR DESCRIPTION
This PR set RBAC enabled by default, set the default Kubernetes version to 1.11.2 and fixes some issues in the deployment script.